### PR TITLE
Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_autosummary/
 
 # PyBuilder
 .pybuilder/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,51 @@
+# Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+
+title: castep-outputs
+author: Jacob Wilkins
+
+# Force re-execution of notebooks on each build.
+# See https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: force
+
+# Define the name of the latex output file for PDF builds
+latex:
+  latex_documents:
+    targetname: castep_outputs_manual.tex
+
+# Add a bibtex file so that we can create citations
+bibtex_bibfiles:
+  - references.bib
+
+# Information about where the book exists on the web
+repository:
+  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
+  path_to_book: docs  # Optional path to your book, relative to the repository root
+  branch: master  # Which branch of the repository should be used when creating links (optional)
+
+# Add GitHub buttons to your book
+# See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
+html:
+  use_issues_button: true
+  use_repository_button: true
+
+sphinx:
+  extra_extensions:
+  - 'sphinx.ext.autodoc'
+  - 'sphinx.ext.autosummary'
+  - 'sphinx.ext.napoleon'
+  - 'sphinx.ext.viewcode'
+  - 'sphinxarg.ext'
+  config:
+    add_module_names: True
+    html_theme: "sphinx_book_theme"
+    napoleon_include_special_with_doc: True
+    napoleon_use_param: True
+    autosummary_generate: True
+    autoclass_content: 'both'
+    autodoc_default_options:
+      members: True
+      inherited-members: True
+      private-members: True
+      show-inheritance: True

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,10 @@
+# Table of contents
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: intro
+chapters:
+- file: installation
+- file: tutorial
+- file: cli
+- file: api

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,15 @@
+API Reference
+=============
+
+.. autosummary::
+   :toctree: _autosummary
+   :recursive:
+
+   castep_outputs
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,7 @@
+Command line interface
+=======================
+
+.. argparse::
+   :module: castep_outputs.args
+   :func: AP
+   :prog: castep_outputs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,46 @@
+Install
+-------
+
+To install ``castep_outputs`` simply run:
+
+::
+
+   pip install castep_outputs
+
+To check it is installed run:
+
+::
+
+   python -m castep_outputs -h
+
+Dependencies
+------------
+
+``castep_outputs`` is designed to have no external dependencies beyond the
+standard library, however, it is possible to use either `PyYAML
+<https://pypi.org/project/PyYAML/>`__ or `ruamel.yaml
+<https://pypi.org/project/ruamel.yaml/>`__ to dump in the YAML format.
+
+This documentation was created using `jupyter-book<https://jupyterbook.org/>`.
+If you want to build the documentation yourself you will need to install
+the additional dependencies listed in ``docs/requirements.txt``. You can do this 
+by installing ``castep_outputs`` with the ``docs`` extra:
+
+::
+
+   pip install castep_outputs[docs]
+
+If installing from a local copy of the repository you can install the
+``docs`` extra by running:
+
+::
+
+   pip install -e .[docs]
+
+
+Note that in `zsh` you will need to escape the square brackets:
+
+::
+
+   pip install -e .\[docs\]
+

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,14 @@
+---
+---
+@article{casteppaper,
+url = {https://doi.org/10.1524/zkri.220.5.567.65075},
+title = {First principles methods using CASTEP},
+author = {Stewart J. Clark and Matthew D. Segall and Chris J. Pickard and Phil J. Hasnip and Matt I. J. Probert and Keith Refson and Mike C. Payne},
+pages = {567--570},
+volume = {220},
+number = {5-6},
+journal = {Zeitschrift für Kristallographie - Crystalline Materials},
+doi = {doi:10.1524/zkri.220.5.567.65075},
+year = {2005},
+lastchecked = {2023-08-09}
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+jupyter-book
+sphinx-argparse

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# castep outputs demo\n",
+    "\n",
+    "In this Jupyter Notebook we'll look at how to use the `castep_outputs` module to process CASTEP output files.\n",
+    "\n",
+    "\n",
+    "This module can be used either as "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import castep_outputs\n",
+    "import logging\n",
+    "# my_dict = castep_outputs.parse_single('./ethanol.castep', loglevel=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     python_requires='>=3.8',
     install_requires=[],
     extras_require={'ruamel': 'ruamel.yaml>=0.17.22',
-                    'yaml': 'PyYAML>=3.13'},
+                    'yaml': 'PyYAML>=3.13',
+                    'docs': ['jupyter-book>=0.13.1', 'sphinx-book-theme>=0.3.3', 'sphinx-argparse>=0.4.0']},
     entry_points={"console_scripts": ['castep_outputs = castep_outputs.castep_outputs_main:main']},
     include_package_data=True
 )


### PR DESCRIPTION

I added some rough documentation based on jupyter-book/sphinx. 

It currently has
- auto-generated API reference
- auto-generated CLI arguments page
- the landing page is an automatically-grabbed copy of README.md
- a skeleton jupyter notebook tutorial (TODO: add in some examples of usage)
- setup.py docs extra (so that people can optionally build the docs themselves)

I have a live version here:

https://jkshenton.github.io/castep_outputs

as an example. 