### PR TITLE
Fix API doc build issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
            python -m pip install --upgrade pip
-           python -m pip install -r docs/requirements.txt
+           pip install ".[docs]"
       - name: Build
         run: |
            jupyter-book build docs


### PR DESCRIPTION
Docs aren't building APIdoc due to not installing `castep-outputs` in the build.