### PR TITLE
Fix some miscellaneous issues breaking expectations/tests

### DIFF
--- a/castep_outputs/cli/args.py
+++ b/castep_outputs/cli/args.py
@@ -61,7 +61,7 @@ def parse_args(to_parse: Sequence[str] = ()) -> argparse.Namespace:
 
     Examples
     --------
-    >>> parse_args()
+    parse_args()
     """
     args = ARG_PARSER.parse_args()
 

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -125,6 +125,7 @@ def parse_all(
     elif isinstance(output, io.TextIOBase):
         file_dumper(data, output)
     else:
+        output = Path(output)
         with output.open("a+", encoding="utf-8") as out_file:
             file_dumper(data, out_file)
 

--- a/castep_outputs/parsers/__init__.py
+++ b/castep_outputs/parsers/__init__.py
@@ -24,26 +24,28 @@ from .tddft_file_parser import parse_tddft_file
 from .ts_file_parser import parse_ts_file
 from .xrd_sf_file_parser import parse_xrd_sf_file
 
-__all__ = ["parse_castep_file",
-           "parse_cell_param_file",
-           "parse_cell_param_file",
-           "parse_md_geom_file",
-           "parse_md_geom_file",
-           "parse_bands_file",
-           "parse_hug_file",
-           "parse_phonon_dos_file",
-           "parse_efield_file",
-           "parse_xrd_sf_file",
-           "parse_elf_fmt_file",
-           "parse_chdiff_fmt_file",
-           "parse_pot_fmt_file",
-           "parse_den_fmt_file",
-           "parse_elastic_file",
-           "parse_ts_file",
-           "parse_magres_file",
-           "parse_tddft_file",
-           "parse_err_file",
-           "parse_phonon_file"]
+__all__ = [
+    "parse_bands_file",
+    "parse_castep_file",
+    "parse_cell_param_file",
+    "parse_cell_param_file",
+    "parse_chdiff_fmt_file",
+    "parse_den_fmt_file",
+    "parse_efield_file",
+    "parse_elastic_file",
+    "parse_elf_fmt_file",
+    "parse_err_file",
+    "parse_hug_file",
+    "parse_magres_file",
+    "parse_md_geom_file",
+    "parse_md_geom_file",
+    "parse_phonon_dos_file",
+    "parse_phonon_file",
+    "parse_pot_fmt_file",
+    "parse_tddft_file",
+    "parse_ts_file",
+    "parse_xrd_sf_file",
+]
 
 
 #: Dictionary of available parsers.

--- a/castep_outputs/utilities/filewrapper.py
+++ b/castep_outputs/utilities/filewrapper.py
@@ -114,7 +114,7 @@ class Block:
             *,
             eof_possible: bool = False,
     ) -> Block:
-        """
+        r"""
         Read the next `n_lines` from `in_file` and return the block.
 
         Parameters
@@ -133,6 +133,16 @@ class Block:
         ------
         IOError
             If EOF reached and ``not eof_possible``.
+
+        Examples
+        --------
+        >>> from io import StringIO
+        >>> x = StringIO('Hello\nThere\nFriend')
+        >>> block = Block.get_lines(x, 2)
+        >>> type(block).__name__
+        'Block'
+        >>> block.aslist()
+        ['Hello\n', 'There\n']
         """
         block = cls(in_file)
 
@@ -140,7 +150,7 @@ class Block:
         for i, line in enumerate(in_file, 1):
             if i > n_lines:
                 break
-            data += line
+            data.append(line)
         else:
             if not eof_possible:
                 if hasattr(in_file, "name"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ruamel = ["ruamel.yaml>=0.17.22"]
 yaml = ["pyYAML>=3.13"]
 docs = ["jupyter-book>=0.13.1", "sphinx-book-theme>=0.3.3", "sphinx-argparse>=0.4.0", "sphinx-autodoc-typehints"]
-lint = ["ruff"]
+lint = ["ruff==0.8.0"]
 
 [project.scripts]
 castep_outputs = "castep_outputs.cli.castep_outputs_main:main"


### PR DESCRIPTION
- Accidentally labelled `parse_args` empty example as doctest causing failure with `pytest --doctest-modules`
- Force `output` to `Path` for required method in `parse_single`
- Make `Block.get_lines` add lines as elements of tuple rather than as characters.
- Fix issue with latest `ruff` version.
- Pin `ruff` version to avoid this problem in future