### PR TITLE
Ignore if coverage report fails

### DIFF
--- a/.github/workflows/test_castep_outputs.yml
+++ b/.github/workflows/test_castep_outputs.yml
@@ -39,6 +39,7 @@ jobs:
         pytest --doctest-modules --cov=castep_outputs --cov-report xml:coverage.xml
     - name: Get Coverage
       uses: orgoro/coverage@v3.2
+      continue-on-error: true
       with:
         coverageFile: coverage.xml
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Forked repos don't necessarily have the tokens for bot. 

Ignore failures on coverage reporting as not essential.