### PR TITLE
Add vermin to CI to check python versions

### DIFF
--- a/.github/workflows/test_castep_outputs.yml
+++ b/.github/workflows/test_castep_outputs.yml
@@ -16,8 +16,23 @@ permissions:
   contents: read
 
 jobs:
+
+  vermin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install vermin
+        run: python -m pip install vermin
+      - name: Run Vermin
+        run: vermin -t=3.8- --lint --no-parse-comments castep_outputs
+
   build:
     runs-on: ubuntu-latest
+    needs: vermin
     permissions:
       pull-requests: write
     strategy:


### PR DESCRIPTION
Ensure that minimum version is supported by quick CI check before testing.