### PR TITLE
Ready castep_outputs for a tool import

### DIFF
--- a/castep_outputs/cli/args.py
+++ b/castep_outputs/cli/args.py
@@ -15,38 +15,49 @@ from castep_outputs.utilities.dumpers import SUPPORTED_FORMATS
 ALL_FORMATS = (*CASTEP_FILE_FORMATS, *BIN_FORMATS)
 ALL_NAMES = (*CASTEP_OUTPUT_NAMES, *BIN_NAMES)
 
-#: Main argument parser for castep outputs.
-ARG_PARSER = argparse.ArgumentParser(
-    prog="castep_outputs",
-    description=f"""Attempts to find all files for seedname, filtered by `inc` args (default: all).
-    Explicit files can be passed using longname arguments.
-    castep_outputs can parse most castep outputs including: {', '.join(ALL_FORMATS)}""",
-)
 
-ARG_PARSER.add_argument("seedname", nargs=argparse.REMAINDER, help="Seed name for data")
-ARG_PARSER.add_argument("-V", "--version", action="version", version=f"%(prog)s v{__version__}")
-ARG_PARSER.add_argument("-L", "--log", help="Verbose output",
-                        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
-                        default="WARNING")
-ARG_PARSER.add_argument("-o", "--output", help="File to write output, default: screen",
-                        default=None)
-ARG_PARSER.add_argument("-f", "--out-format", help="Output format", choices=SUPPORTED_FORMATS,
-                        default="json")
+def get_parser() -> argparse.ArgumentParser:
+    """Get main argument parser for castep outputs.
 
-ARG_PARSER.add_argument("-t", "--testing", action="store_true",
-                        help="Set testing mode to produce flat outputs")
+    Returns
+    -------
+    argparse.ArgumentParser
+        castep_outputs argument parser.
+    """
+    arg_parser = argparse.ArgumentParser(
+        prog="castep_outputs",
+        description=f"""\
+        Attempts to find all files for seedname, filtered by `inc` args (default: all).
+        Explicit files can be passed using longname arguments.
+        castep_outputs can parse most castep outputs including: {', '.join(ALL_FORMATS)}""",
+    )
 
-ARG_PARSER.add_argument("-A", "--inc-all", action="store_true",
-                        help="Extract all available information")
+    arg_parser.add_argument("seedname", nargs=argparse.REMAINDER, help="Seed name for data")
+    arg_parser.add_argument("-V", "--version", action="version", version=f"%(prog)s v{__version__}")
+    arg_parser.add_argument("-L", "--log", help="Verbose output",
+                            choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+                            default="WARNING")
+    arg_parser.add_argument("-o", "--output", help="File to write output, default: screen",
+                            default=None)
+    arg_parser.add_argument("-f", "--out-format", help="Output format", choices=SUPPORTED_FORMATS,
+                            default="json")
 
-for output_name in ALL_NAMES:
-    ARG_PARSER.add_argument(f"--inc-{output_name}", action="store_true",
-                            help=f"Extract .{output_name} information")
+    arg_parser.add_argument("-t", "--testing", action="store_true",
+                            help="Set testing mode to produce flat outputs")
 
-for output_name in ALL_NAMES:
-    ARG_PARSER.add_argument(f"--{output_name}", nargs="*",
-                            help=f"Extract from {output_name.upper()} as .{output_name} type",
-                            default=[])
+    arg_parser.add_argument("-A", "--inc-all", action="store_true",
+                            help="Extract all available information")
+
+    for output_name in ALL_NAMES:
+        arg_parser.add_argument(f"--inc-{output_name}", action="store_true",
+                                help=f"Extract .{output_name} information")
+
+    for output_name in ALL_NAMES:
+        arg_parser.add_argument(f"--{output_name}", nargs="*",
+                                help=f"Extract from {output_name.upper()} as .{output_name} type",
+                                default=[])
+
+    return arg_parser
 
 
 def parse_args(to_parse: Sequence[str] = ()) -> argparse.Namespace:
@@ -67,7 +78,7 @@ def parse_args(to_parse: Sequence[str] = ()) -> argparse.Namespace:
     --------
     parse_args()
     """
-    args = ARG_PARSER.parse_args()
+    args = get_parser().parse_args()
 
     parse_all = args.inc_all or not any(getattr(args, f"inc_{typ}") for typ in ALL_NAMES)
 

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -1,6 +1,7 @@
 """Main castep parser access routines."""
 from __future__ import annotations
 
+import argparse
 import io
 import logging
 import sys
@@ -135,9 +136,14 @@ def parse_all(
             file_dumper(data, out_file)
 
 
-def main() -> None:
-    """Run the main program from command line."""
-    args = parse_args()
+def run(args: argparse.Namespace) -> None:
+    """Runner for main program.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Run arguments.
+    """
     dict_args = extract_parsables(args)
 
     parse_all(output=args.output,
@@ -145,6 +151,12 @@ def main() -> None:
               testing=args.testing,
               out_format=args.out_format,
               **dict_args)
+
+
+def main() -> None:
+    """Run the main program from command line."""
+    args = parse_args()
+    run(args)
 
 
 if __name__ == "__main__":

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -1,22 +1,26 @@
 """Main castep parser access routines."""
 from __future__ import annotations
 
-import argparse
 import io
 import logging
 import sys
 from collections import ChainMap
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
-from ..bin_parsers import PARSERS as BIN_PARSERS
-from ..parsers import PARSERS
-from ..parsers.castep_file_parser import Filters
-from ..utilities.constants import OutFormats
-from ..utilities.dumpers import get_dumpers
-from ..utilities.utility import flatten_dict, json_safe, normalise
+from castep_outputs.bin_parsers import PARSERS as BIN_PARSERS
+from castep_outputs.parsers import PARSERS
+from castep_outputs.parsers.castep_file_parser import Filters
+from castep_outputs.utilities.dumpers import get_dumpers
+from castep_outputs.utilities.utility import flatten_dict, json_safe, normalise
+
 from .args import extract_parsables, parse_args
+
+if TYPE_CHECKING:
+    import argparse
+
+    from castep_outputs.utilities.constants import OutFormats
 
 ALL_PARSERS = ChainMap(PARSERS, BIN_PARSERS)
 


### PR DESCRIPTION
Make `castep_outputs` ready for integration as tool in `castep_output_tools` when oerc0122/castep_outputs_tools#18 or oerc0122/castep_outputs_tools#19 merged.