### PR TITLE
Deprecate Python 3.8 and associated fixes

### DIFF
--- a/.github/workflows/test_castep_outputs.yml
+++ b/.github/workflows/test_castep_outputs.yml
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_castep_outputs.yml
+++ b/.github/workflows/test_castep_outputs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install vermin
         run: python -m pip install vermin
       - name: Run Vermin
-        run: vermin -t=3.8- --lint --no-parse-comments castep_outputs
+        run: vermin -t=3.9- --lint --no-parse-comments castep_outputs
 
   build:
     runs-on: ubuntu-latest

--- a/castep_outputs/bin_parsers/fortran_bin_parser.py
+++ b/castep_outputs/bin_parsers/fortran_bin_parser.py
@@ -1,6 +1,7 @@
 """General parser for the Fortran Unformatted file format."""
+from collections.abc import Generator
 from os import SEEK_CUR
-from typing import BinaryIO, Generator
+from typing import BinaryIO
 
 FortranBinaryReader = Generator[bytes, int, None]
 

--- a/castep_outputs/parsers/bands_file_parser.py
+++ b/castep_outputs/parsers/bands_file_parser.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Literal, TextIO, TypedDict
+from typing import Literal, TextIO, TypedDict
 
 from ..utilities import castep_res as REs
 from ..utilities.datatypes import ThreeVector
@@ -35,7 +35,7 @@ BandsFileInfo = TypedDict("BandsFileInfo", {
     "spin components": int,
     "Fermi Energy": float,
     "coords": dict,
-    "bands": List[BandsQData],
+    "bands": list[BandsQData],
     })
 
 

--- a/castep_outputs/parsers/castep_file_parser.py
+++ b/castep_outputs/parsers/castep_file_parser.py
@@ -13,7 +13,7 @@ import itertools
 import re
 from collections import defaultdict
 from enum import Flag, auto
-from typing import Any, Dict, List, TextIO, Union, cast
+from typing import Any, TextIO, Union, cast
 
 from ..utilities import castep_res as REs
 from ..utilities.castep_res import gen_table_re, get_numbers, labelled_floats
@@ -1779,7 +1779,7 @@ def _process_initial_spins(block: Block) -> dict[AtomIndex, InitialSpin]:
             ind = atreg_to_index(val)
             fix_data_types(val, {"spin": float, "magmom": float})
             val["fix"] = val["fix"] == "T"
-            accum[ind] = cast(Dict[str, Union[float, bool]], val)
+            accum[ind] = cast(dict[str, Union[float, bool]], val)
     return accum
 
 
@@ -2232,7 +2232,7 @@ def _process_occupancies(block: Block) -> list[Occupancies]:
         fix_data_types(elem, {"band": int,
                               "eigenvalue": float,
                               "occupancy": float})
-    return cast(List[Occupancies], accum)
+    return cast(list[Occupancies], accum)
 
 
 def _process_wvfn_line_min(block: Block) -> WvfnLineMin:
@@ -2404,7 +2404,7 @@ def _process_geom_table(block: Block) -> GeomTable:
             fix_data_types(val, dict.fromkeys(("lambda", "fdelta", "enthalpy"), float))
 
             key = normalise_string(val.pop("step"))
-            accum[key] = cast(Dict[str, Union[bool, float]], val)
+            accum[key] = cast(dict[str, Union[bool, float]], val)
 
         elif match := REs.GEOMOPT_TABLE_RE.match(line):
             val = match.groupdict()
@@ -2413,7 +2413,7 @@ def _process_geom_table(block: Block) -> GeomTable:
             val["converged"] = val["converged"] == "Yes"
 
             key = normalise_key(val.pop("parameter"))
-            accum[key] = cast(Dict[str, Union[bool, float]], val)
+            accum[key] = cast(dict[str, Union[bool, float]], val)
 
     return accum
 

--- a/castep_outputs/parsers/cell_param_file_parser.py
+++ b/castep_outputs/parsers/cell_param_file_parser.py
@@ -6,7 +6,7 @@ import typing
 from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, Dict, List, Literal, TextIO, Tuple, TypedDict, Union
+from typing import Any, Literal, TextIO, TypedDict, Union
 
 import castep_outputs.utilities.castep_res as REs
 
@@ -50,14 +50,14 @@ class NonLinearConstraint(TypedDict):
     #: Atoms and constraint definition.
     atoms: dict[AtomIndex, ThreeVector]
 
-DevelElem = MaybeSequence[Union[str, float, Dict[str, Union[str, float]]]]
-DevelBlock = Dict[str, Union[DevelElem, Dict[str, DevelElem]]]
-HubbardU = Dict[Union[str, AtomIndex], Union[str, Dict[str, float]]]
-CellParamData = Dict[str, Union[str, float, Tuple[float, str],
-                                Dict[str, Any], HubbardU, DevelBlock]]
-GeneralBlock = Dict[str, Union[
-    List[Union[str, float]],
-    Dict[str, MaybeSequence[float]],
+DevelElem = MaybeSequence[Union[str, float, dict[str, Union[str, float]]]]
+DevelBlock = dict[str, Union[DevelElem, dict[str, DevelElem]]]
+HubbardU = dict[Union[str, AtomIndex], Union[str, dict[str, float]]]
+CellParamData = dict[str, Union[str, float, tuple[float, str],
+                                dict[str, Any], HubbardU, DevelBlock]]
+GeneralBlock = dict[str, Union[
+    list[Union[str, float]],
+    dict[str, MaybeSequence[float]],
 ]]
 
 
@@ -409,7 +409,7 @@ def _parse_general(block: Block) -> GeneralBlock:
         if REs.SPEC_PROP_RE.match(line):
             if isinstance(block_data["data"], list):
                 block_data["data"] = {}
-                typing.cast(Dict[str, MaybeSequence[Union[float, str]]],
+                typing.cast(dict[str, MaybeSequence[Union[float, str]]],
                             block_data["data"])
 
             spec, val = line.strip().split(maxsplit=1)

--- a/castep_outputs/parsers/tddft_file_parser.py
+++ b/castep_outputs/parsers/tddft_file_parser.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Literal, TextIO, Tuple, TypedDict, Union
+from typing import Literal, TextIO, TypedDict, Union
 
 from ..utilities import castep_res as REs
 from ..utilities.castep_res import get_numbers, labelled_floats
@@ -12,7 +12,7 @@ from ..utilities.utility import file_or_path, to_type
 from .parse_utilities import parse_regular_header
 
 #: Overlap type
-TDDFTOverlap = Dict[Union[Tuple[int, int], Literal["total"]], float]
+TDDFTOverlap = dict[Union[tuple[int, int], Literal["total"]], float]
 
 
 class TDDFTSpectroData(TypedDict):

--- a/castep_outputs/utilities/datatypes.py
+++ b/castep_outputs/utilities/datatypes.py
@@ -1,19 +1,17 @@
 """Types produced by castep_outputs."""
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Literal, TypedDict, TypeVar, Union
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, TextIO, TypedDict, TypeVar, Union
 
 T = TypeVar("T")
 
 #: Parser protocol
-ParserFunction = Callable  # [[TextIO], Dict[str, Any]] limited by 3.8
+ParserFunction = Callable[[TextIO], dict[str, Any]]
 
 # General types
 
-# Python 3.8 doesn't support concrete Sequence
-# MaybeSequence = Union[Sequence[T], T]
-MaybeSequence = Union[T, list[T], tuple[T, ...]]
+MaybeSequence = Union[Sequence[T], T]
 
 #: CASTEP atom keys.
 AtomIndex = tuple[str, int]

--- a/castep_outputs/utilities/datatypes.py
+++ b/castep_outputs/utilities/datatypes.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Dict, List, Literal, Tuple, TypedDict, TypeVar, Union
+from typing import Literal, TypedDict, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -13,20 +13,20 @@ ParserFunction = Callable  # [[TextIO], Dict[str, Any]] limited by 3.8
 
 # Python 3.8 doesn't support concrete Sequence
 # MaybeSequence = Union[Sequence[T], T]
-MaybeSequence = Union[T, List[T], Tuple[T, ...]]
+MaybeSequence = Union[T, list[T], tuple[T, ...]]
 
 #: CASTEP atom keys.
-AtomIndex = Tuple[str, int]
+AtomIndex = tuple[str, int]
 #: Standard 3D vector.
-ThreeVector = Tuple[float, float, float]
+ThreeVector = tuple[float, float, float]
 #: Complex 3D vector.
-ComplexThreeVector = Tuple[complex, complex, complex]
+ComplexThreeVector = tuple[complex, complex, complex]
 #: Voigt notation vector.
-SixVector = Tuple[float, float, float, float, float, float]
+SixVector = tuple[float, float, float, float, float, float]
 #: Three by three matrix.
-ThreeByThreeMatrix = Tuple[ThreeVector, ThreeVector, ThreeVector]
+ThreeByThreeMatrix = tuple[ThreeVector, ThreeVector, ThreeVector]
 #: Atom properties linking unique atom to a physical property.
-AtomPropBlock = Dict[AtomIndex, ThreeVector]
+AtomPropBlock = dict[AtomIndex, ThreeVector]
 
 
 class CellInfo(TypedDict):
@@ -366,7 +366,7 @@ class BondInfo(TypedDict):
 
 
 #: Full bond information for all pairs.
-BondData = Dict[Tuple[AtomIndex, AtomIndex], BondInfo]
+BondData = dict[tuple[AtomIndex, AtomIndex], BondInfo]
 
 
 class MullikenInfo(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "castep_outputs"
 authors = [{name = "Jacob Wilkins", email = "jacob.wilkins@stfc.ac.uk"}]
 dynamic = ["version"]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 readme = "README.rst"
 description = "A package for extracting information from castep outputs"
 keywords = ["castep", "dft", "parser"]
@@ -51,7 +51,7 @@ version = {attr = "castep_outputs.__version__"}
 [tool.ruff]
 line-length = 100
 indent-width = 4
-target-version = "py38"
+target-version = "py39"
 
 # Exclude a variety of commonly ignored directories.
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
 
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 is EoL and limits functionality.

(also stop complaints)