### PR TITLE
Enable extended ruff checks

### DIFF
--- a/castep_outputs/bin_parsers/cst_esp_file_parser.py
+++ b/castep_outputs/bin_parsers/cst_esp_file_parser.py
@@ -45,7 +45,7 @@ def parse_cst_esp_file(cst_esp_file: BinaryIO) -> ESPData:
     prev_nx = None
     curr = []
     for datum in reader:
-        nx, ny = to_type(datum[:8], int)
+        nx, _ny = to_type(datum[:8], int)
         if prev_nx != nx and curr:
             accum["esp"].append(curr)
             curr = []

--- a/castep_outputs/bin_parsers/fortran_bin_parser.py
+++ b/castep_outputs/bin_parsers/fortran_bin_parser.py
@@ -5,6 +5,7 @@ from typing import BinaryIO
 
 FortranBinaryReader = Generator[bytes, int, None]
 
+
 def binary_file_reader(file: BinaryIO) -> FortranBinaryReader:
     """Yield the elements of a Fortran unformatted file.
 
@@ -47,14 +48,14 @@ def binary_file_reader(file: BinaryIO) -> FortranBinaryReader:
         if skip:  # NB. Send proceeds to yield.
             # `True` implies rewind 1
             if skip < 0 or skip is True:
-                for _ in range(abs(skip)-1):
+                for _ in range(abs(skip) - 1):
                     # Rewind to record size before last read
-                    file.seek(-size-12, SEEK_CUR)
+                    file.seek(-size - 12, SEEK_CUR)
                     size = int.from_bytes(file.read(4), "big")
 
                 # Rewind one extra (which will be yielded)
-                file.seek(-size-8, SEEK_CUR)
+                file.seek(-size - 8, SEEK_CUR)
             else:
                 for _ in range(skip):
                     size = int.from_bytes(file.read(4), "big")
-                    file.seek(size+4, SEEK_CUR)
+                    file.seek(size + 4, SEEK_CUR)

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -48,7 +48,7 @@ def parse_single(in_file: str | Path | TextIO,
 
     Raises
     ------
-    KeyError
+    ValueError
         If invalid `parser` provided.
     """
     logging.basicConfig(format="%(levelname)s: %(message)s", level=loglevel)
@@ -60,11 +60,12 @@ def parse_single(in_file: str | Path | TextIO,
         ext = in_file.suffix.strip(".")
 
         if ext not in ALL_PARSERS:
-            raise KeyError(f"Parser for file {in_file} (assumed type: {ext}) not found")
+            raise ValueError(f"Parser for file {in_file} (assumed type: {ext}) not found")
 
         parser = ALL_PARSERS[ext]
 
-    assert parser is not None
+    if parser is None:
+        raise ValueError("Unable to determine parser. Please specify through arguments.")
 
     data = parser(in_file)
 

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -50,8 +50,6 @@ def parse_single(in_file: str | Path | TextIO,
     ------
     KeyError
         If invalid `parser` provided.
-    AssertionError
-        Parser loading error.
     """
     logging.basicConfig(format="%(levelname)s: %(message)s", level=loglevel)
 
@@ -72,7 +70,7 @@ def parse_single(in_file: str | Path | TextIO,
 
     if out_format == "json" or testing:
         data = normalise(data, {dict: json_safe, complex: json_safe})
-    elif out_format in ("yaml", "ruamel"):
+    elif out_format in {"yaml", "ruamel"}:
         data = normalise(data, {tuple: list})
 
     if testing:

--- a/castep_outputs/parsers/bands_file_parser.py
+++ b/castep_outputs/parsers/bands_file_parser.py
@@ -84,7 +84,6 @@ def parse_bands_file(bands_file: TextIO) -> BandsFileInfo:
         elif re.match(rf"^\s*{REs.FNUMBER_RE}$", line.strip()):
             accum.append(line.strip())
 
-
     if qdata:
         qdata[current] = to_type(accum, float)
         qdata["spin_comp"] = "band_down" in qdata

--- a/castep_outputs/parsers/cell_param_file_parser.py
+++ b/castep_outputs/parsers/cell_param_file_parser.py
@@ -42,6 +42,7 @@ class PositionsInfo(TypedDict, total=False):
     #: Mixture weight.
     weight: float
 
+
 class NonLinearConstraint(TypedDict):
     """Non-linear constraint information."""
 
@@ -49,6 +50,7 @@ class NonLinearConstraint(TypedDict):
     key: Literal["distance", "bend", "torsion"]
     #: Atoms and constraint definition.
     atoms: dict[AtomIndex, ThreeVector]
+
 
 DevelElem = MaybeSequence[Union[str, float, dict[str, Union[str, float]]]]
 DevelBlock = dict[str, Union[DevelElem, dict[str, DevelElem]]]
@@ -108,7 +110,7 @@ def parse_cell_param_file(cell_param_file: TextIO) -> list[CellParamData]:
 
     for line in cell_param_file:
         # Strip comments
-        line = re.split("[#!]", line)[0]
+        line = re.split(r"[#!]", line)[0]
 
         if block := Block.from_re(line, cell_param_file,
                                   re.compile(r"^\s*%block ", re.IGNORECASE),
@@ -170,12 +172,11 @@ def _parse_devel_code_block(in_block: Block) -> DevelBlock:
         block: DevelBlock = {}
         for par in re.finditer(REs.DEVEL_CODE_VAL_RE, block_str,
                                re.IGNORECASE | re.MULTILINE):
-            key, val = re.split("[:=]", par.group(0))
+            key, val = re.split(r"[:=]", par.group(0))
             key = normalise_key(key)
             typ = determine_type(val)
             block[key] = to_type(val, typ)
             block_str = block_str.replace(par.group(0), "")
-
 
         if block_str.strip():
             block["data"] = []
@@ -184,16 +185,16 @@ def _parse_devel_code_block(in_block: Block) -> DevelBlock:
                 block["data"].append(to_type(par, determine_type(par)))
 
         if block_title in devel_code_parsed:
-            devel_code_parsed[block_title].update(block) # type: ignore
+            devel_code_parsed[block_title].update(block)  # type: ignore
         else:
-            devel_code_parsed[block_title] = block # type: ignore
+            devel_code_parsed[block_title] = block  # type: ignore
 
         # Remove matched to get remainder
         main_block = main_block.replace(blk.group(0), "")
 
     # Catch remainder
     for par in re.finditer(REs.DEVEL_CODE_VAL_RE, main_block):
-        key, val = re.split("[:=]", par.group(0))
+        key, val = re.split(r"[:=]", par.group(0))
         key = normalise_key(key)
         typ = determine_type(val)
 
@@ -228,6 +229,7 @@ def _parse_ionic_constraints(block: Block) -> dict[AtomIndex, Sequence[ThreeVect
             accum[ind].append(elem)
 
     return dict(accum)
+
 
 def _parse_nonlinear_constraints(block: Block) -> list[NonLinearConstraint]:
     """
@@ -301,6 +303,7 @@ def _parse_positions(block: Block, *, absolute: bool = False) -> dict[AtomIndex,
             accum[ind] = info
 
     return accum
+
 
 def _parse_hubbard_u(block: Block) -> HubbardU:
     """
@@ -383,9 +386,10 @@ def _parse_symops(block: Block) -> list[dict[str, ThreeByThreeMatrix | ThreeVect
            for line in block
            if (numbers := REs.FLOAT_RAT_RE.findall(line))]
 
-    return [{"r": tmp[i:i+3],  # type: ignore
-             "t": tmp[i+3]}
+    return [{"r": tmp[i:i + 3],  # type: ignore
+             "t": tmp[i + 3]}
             for i in range(0, len(tmp), 4)]
+
 
 def _parse_general(block: Block) -> GeneralBlock:
     """
@@ -404,7 +408,7 @@ def _parse_general(block: Block) -> GeneralBlock:
     block_data: GeneralBlock = {"data": []}
 
     for line in block:
-        line = re.split("[#!]", line)[0]
+        line = re.split(r"[#!]", line)[0]
 
         if REs.SPEC_PROP_RE.match(line):
             if isinstance(block_data["data"], list):
@@ -430,6 +434,7 @@ def _parse_general(block: Block) -> GeneralBlock:
             block_data["units"] = line.strip()
 
     return block_data
+
 
 _parse_positions_abs = partial(_parse_positions, absolute=True)
 _parse_positions_frac = partial(_parse_positions, absolute=False)

--- a/castep_outputs/parsers/md_geom_file_parser.py
+++ b/castep_outputs/parsers/md_geom_file_parser.py
@@ -105,6 +105,7 @@ def parse_md_geom_frame(block: Block) -> MDGeomTimestepInfo:
 
     return curr
 
+
 @file_or_path(mode="r")
 def parse_md_geom_file(md_geom_file: TextIO) -> list[MDGeomTimestepInfo]:
     """

--- a/castep_outputs/parsers/parse_fmt_files.py
+++ b/castep_outputs/parsers/parse_fmt_files.py
@@ -7,20 +7,64 @@ from .parse_utilities import parse_kpt_info
 
 
 def parse_elf_fmt_file(elf_file: TextIO) -> dict[str, list[int | float]]:
-    """Parse castep .elf_fmt files."""
+    """Parse castep .elf_fmt files.
+
+    Parameters
+    ----------
+    elf_file : TextIO
+        File to parse.
+
+    Returns
+    -------
+    dict[str, list[int | float]]
+        Parsed data.
+    """
     return parse_kpt_info(elf_file, ("chi_alpha", "chi_beta"))
 
 
 def parse_chdiff_fmt_file(chdiff_file: TextIO) -> dict[str, list[int | float]]:
-    """Parse castep .chdiff_fmt files."""
+    """Parse castep .chdiff_fmt files.
+
+    Parameters
+    ----------
+    chdiff_file : TextIO
+        File to parse.
+
+    Returns
+    -------
+    dict[str, list[int | float]]
+        Parsed data.
+    """
     return parse_kpt_info(chdiff_file, "chdiff")
 
 
 def parse_pot_fmt_file(pot_file: TextIO) -> dict[str, list[int | float]]:
-    """Parse castep .pot_fmt files."""
+    """Parse castep .pot_fmt files.
+
+    Parameters
+    ----------
+    pot_file : TextIO
+        File to parse.
+
+    Returns
+    -------
+    dict[str, list[int | float]]
+        Parsed data.
+    """
     return parse_kpt_info(pot_file, "pot")
 
 
 def parse_den_fmt_file(den_file: TextIO) -> dict[str, list[int | float]]:
-    """Parse castep .den_fmt files."""
+    """Parse castep .den_fmt files.
+
+    Parameters
+    ----------
+    den_file : TextIO
+        File to parse.
+
+    Returns
+    -------
+    dict[str, list[int | float]]
+        Parsed data.
+    """
     return parse_kpt_info(den_file, "density")

--- a/castep_outputs/parsers/phonon_file_parser.py
+++ b/castep_outputs/parsers/phonon_file_parser.py
@@ -43,6 +43,11 @@ def parse_phonon_file(phonon_file: TextIO) -> PhononFileInfo:
     phonon_file
         A handle to a CASTEP .phonon file.
 
+    Raises
+    ------
+    ValueError
+        Branches count doesn't match expected.
+
     Returns
     -------
     PhononFileInfo
@@ -78,7 +83,7 @@ def parse_phonon_file(phonon_file: TextIO) -> PhononFileInfo:
             if len(block) - 2 != phonon_info["branches"]:
                 raise ValueError("Malformed phonon frequencies. "
                                  f"Expected {phonon_info['branches']} branches, "
-                                 f"received {len(block)-2}")
+                                 f"received {len(block) - 2}")
 
             block.remove_bounds(1, 1)
 
@@ -101,7 +106,7 @@ def parse_phonon_file(phonon_file: TextIO) -> PhononFileInfo:
             if len(block) - 1 != expected_n_eigenvec:
                 raise ValueError("Malformed eigenvectors. "
                                  f"Expected {expected_n_eigenvec} branches, "
-                                 f"received {len(block)-1}")
+                                 f"received {len(block) - 1}")
 
             block.remove_bounds(1, 0)
 

--- a/castep_outputs/parsers/tddft_file_parser.py
+++ b/castep_outputs/parsers/tddft_file_parser.py
@@ -68,7 +68,7 @@ def parse_tddft_file(tddft_file: TextIO) -> TDDFTFileInfo:
 
             for blk_line in block:
                 if match := REs.TDDFT_STATE_RE.match(blk_line):
-                    curr[(int(match["occ"]), int(match["unocc"]))] = float(match["overlap"])
+                    curr[int(match["occ"]), int(match["unocc"])] = float(match["overlap"])
 
                 elif match := re.match(r"\s*Total overlap for state", blk_line):
                     curr["total"] = float(get_numbers(blk_line)[-1])
@@ -91,7 +91,8 @@ def parse_tddft_file(tddft_file: TextIO) -> TDDFTFileInfo:
                     match["energy"] = float(match["energy"])
 
                     dip = list(to_type(get_numbers(match["dipoles"]), float))
-                    dip = [complex(real, imag) for real, imag in zip(dip[0::2], dip[1::2])]
+                    dip = list(map(complex, dip[0::2], dip[1::2]))
+
                     match["dipoles"] = dip
                     tddft_info["spectroscopic_data"].append(match)
 

--- a/castep_outputs/parsers/xrd_sf_file_parser.py
+++ b/castep_outputs/parsers/xrd_sf_file_parser.py
@@ -52,7 +52,7 @@ def parse_xrd_sf_file(xrd_sf_file: TextIO) -> XRDSFFileInfo:
     # Get headers from first line
     headers = xrd_sf_file.readline().split()[3:]
     # Turn Re(x) into x_re
-    headers = [(head[3:-1]+"_"+head[0:2]).lower() for head in headers]
+    headers = [f"{head[3:-1]}_{head[0:2]}".lower() for head in headers]
     headers_wo = {head[:-3] for head in headers}
 
     xrd_re = re.compile(rf"(?P<qvec>(?:\s*{REs.INTNUMBER_RE}){{3}})" +

--- a/castep_outputs/processing/processing.py
+++ b/castep_outputs/processing/processing.py
@@ -6,6 +6,7 @@ from ..utilities.castep_res import get_atom_parts
 
 Self = TypeVar("Self", bound="AtomLabel")
 
+
 class AtomLabel(NamedTuple):
     """Standard castep atom label."""
 

--- a/castep_outputs/utilities/castep_res.py
+++ b/castep_outputs/utilities/castep_res.py
@@ -351,12 +351,14 @@ FORCES_BLOCK_RE = re.compile(gen_table_re("([a-zA-Z ]*)Forces", r"\*+"), re.IGNO
 STRESSES_BLOCK_RE = re.compile(gen_table_re("([a-zA-Z ]*)Stress Tensor", r"\*+"), re.IGNORECASE)
 
 # Bonds
-BOND_RE = re.compile(rf"""\s*
-                       (?P<spec1>{ATOM_NAME_RE})\s*(?P<ind1>\d+)\s*
-                       --\s*
-                       (?P<spec2>{ATOM_NAME_RE})\s*(?P<ind2>\d+)\s*
-                       {labelled_floats(("population", "spin", "length"), counts=(None,"0,1",None))}
-                       """, re.VERBOSE)
+BOND_RE = re.compile(
+    rf"""\s*
+    (?P<spec1>{ATOM_NAME_RE})\s*(?P<ind1>\d+)\s*
+    --\s*
+    (?P<spec2>{ATOM_NAME_RE})\s*(?P<ind2>\d+)\s*
+    {labelled_floats(("population", "spin", "length"), counts=(None, "0,1", None))}
+    """, re.VERBOSE,
+)
 
 # Pair pot
 PAIR_POT_RES = {
@@ -436,7 +438,7 @@ BS_RE = re.compile(
     rf"""
     Spin=\s*(?P<spin>{INTNUMBER_RE})\s*
     kpt=\s*{INTNUMBER_RE}\s*
-    \({labelled_floats(("kx","ky","kz"))}\)\s*
+    \({labelled_floats(("kx", "ky", "kz"))}\)\s*
     kpt-group=\s*(?P<kpgrp>{INTNUMBER_RE})
     """, re.VERBOSE)
 
@@ -473,17 +475,18 @@ BORN_RE = re.compile(rf"\s+{ATOM_RE}(?P<charges>(?:\s*{FNUMBER_RE}){{3}})(?:\s*I
 # MagRes REs
 MAGRES_RE = (
     # "Chemical Shielding Tensor" 0
-    re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('iso','aniso'))}\s*"
+    re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('iso', 'aniso'))}\s*"
                rf"(?P<asym>{FNUMBER_RE}|N/A)\s*\|\s*"),
     # "Chemical Shielding and Electric Field Gradient Tensor" 1
-    re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('iso','aniso'))}\s*"
+    re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('iso', 'aniso'))}\s*"
                rf"(?P<asym>{FNUMBER_RE}|N/A)"
                rf"{labelled_floats(('cq', 'eta'))}\s*\|\s*"),
     # "Electric Field Gradient Tensor" 2
     re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('cq',))}\s*"
                rf"(?P<asym>{FNUMBER_RE}|N/A)\s*\|\s*"),
     # "(?:I|Ani)sotropic J-coupling" 3
-    re.compile(rf"\s*\|\**\s*{ATOM_RE}{labelled_floats(('fc','sd','para','dia','tot'))}\s*\|\s*"),
+    re.compile(rf"\s*\|\**\s*{ATOM_RE}"
+               rf"{labelled_floats(('fc', 'sd', 'para', 'dia', 'tot'))}\s*\|\s*"),
     # "Hyperfine Tensor" 4
     re.compile(rf"\s*\|\s*{ATOM_RE}{labelled_floats(('iso',))}\s*\|\s*"),
 )

--- a/castep_outputs/utilities/datatypes.py
+++ b/castep_outputs/utilities/datatypes.py
@@ -159,6 +159,7 @@ class DelocActiveSpace(TypedDict):
     #: Size of the active space.
     active_space_size: int
 
+
 # Dipole
 
 class DipoleTable(TypedDict):
@@ -177,8 +178,8 @@ class DipoleTable(TypedDict):
     #: Total valence charge in system in fundamental charge.
     total_valence: float
 
-# Phonon
 
+# Phonon
 
 class CharTable(TypedDict):
     """Character table from group theory analysis of eigenvectors."""
@@ -237,6 +238,7 @@ class RamanReport(TypedDict, total=False):
     ii: float
     #: Depolarisation ratio in 0.5 A/amu.
     depolarisation: float | None
+
 
 # Occupancies
 
@@ -724,8 +726,8 @@ class TDDFTData(TypedDict):
     #: Whether state is: Spurious, Single, Doublet, etc.
     type: str
 
-# Other Files
 
+# Other Files
 
 class HeaderAtomInfo(TypedDict):
     """Atom info from header."""

--- a/castep_outputs/utilities/dumpers.py
+++ b/castep_outputs/utilities/dumpers.py
@@ -130,6 +130,7 @@ def get_dumpers(dump_fmt: str) -> Dumper:
 
     return SUPPORTED_FORMATS[dump_fmt]
 
+
 #: Currently supported dumpers.
 SUPPORTED_FORMATS: dict[str, Dumper] = {"json": json_dumper,
                                         "ruamel": ruamel_dumper,

--- a/castep_outputs/utilities/filewrapper.py
+++ b/castep_outputs/utilities/filewrapper.py
@@ -8,7 +8,8 @@ from typing import NoReturn, TextIO, TypeVar
 
 from .castep_res import Pattern
 
-Self = TypeVar("Self", bound="FileWrapper")
+FWSelf = TypeVar("FWSelf", bound="FileWrapper")
+
 
 class FileWrapper:
     """
@@ -20,12 +21,12 @@ class FileWrapper:
         File to wrap and control.
     """
 
-    def __init__(self, file: TextIO) -> Self:
+    def __init__(self, file: TextIO) -> FWSelf:
         self._file = file
         self._pos = 0
         self._lineno = 0
 
-    def __iter__(self) -> Self:
+    def __iter__(self) -> FWSelf:
         return self
 
     def __next__(self) -> str:
@@ -89,7 +90,8 @@ class FileWrapper:
         return self.file.name if hasattr(self.file, "name") else "unknown"
 
 
-Self = TypeVar("Self", bound="Block")
+BSelf = TypeVar("BSelf", bound="Block")
+
 
 class Block:
     """
@@ -133,7 +135,7 @@ class Block:
 
         Raises
         ------
-        IOError
+        OSError
             If EOF reached and ``not eof_possible``.
 
         Examples
@@ -202,7 +204,7 @@ class Block:
 
         Raises
         ------
-        IOError
+        OSError
             If EOF reached and ``not eof_possible``.
         """
         block = cls(in_file)
@@ -235,7 +237,7 @@ class Block:
             cls,
             data: Sequence[str],
             parent: TextIO | FileWrapper | Block | None = None,
-    ) -> Self:
+    ) -> BSelf:
         r"""
         Construct a Block from an iterable containing strings.
 
@@ -243,6 +245,11 @@ class Block:
         ----------
         data
             Data to read into block.
+
+        Returns
+        -------
+        Self
+            Block from an iterable.
 
         Examples
         --------
@@ -303,6 +310,11 @@ class Block:
         Useful for blocks not terminated by a clear
         statement, where we can only check if next line
         does *NOT* match.
+
+        Raises
+        ------
+        ValueError
+            Block already rewound fully.
         """
         if self._i < 0:
             self._i = -1
@@ -316,7 +328,7 @@ class Block:
     def __str__(self) -> str:
         return "\n".join(self._data)
 
-    def __iter__(self) -> Self:
+    def __iter__(self) -> BSelf:
         return self
 
     def __next__(self) -> str:

--- a/castep_outputs/utilities/utility.py
+++ b/castep_outputs/utilities/utility.py
@@ -27,6 +27,7 @@ NORMALISE_RE = re.compile(r"[_\W]+")
 LoggingLevels = Literal["debug", "info", "warning", "error", "critical"]
 Logger = Callable[[str, tuple[Any, ...], LoggingLevels], None]
 
+
 def normalise_string(string: str) -> str:
     """
     Normalise a string.
@@ -382,7 +383,7 @@ def determine_type(data: str) -> type:
     >>> determine_type('BEEF')
     <class 'str'>
     """
-    if data.title() in ("T", "True", "F", "False"):
+    if data.title() in {"T", "True", "F", "False"}:
         return bool
 
     if re.match(rf"(?:\s*{REs.EXPFNUMBER_RE})+", data):
@@ -477,7 +478,7 @@ def _parse_logical(val: str) -> bool:
     >>> _parse_logical("F")
     False
     """
-    return val.title() in ("T", "True", "1")
+    return val.title() in {"T", "True", "1"}
 
 
 def _parse_float_bytes(val: bytes) -> float | Sequence[float]:
@@ -504,8 +505,9 @@ def _parse_float_bytes(val: bytes) -> float | Sequence[float]:
     >>> _parse_float_bytes(one*3)
     (1.0, 1.0, 1.0)
     """
-    result = unpack(f">{len(val)//8}d", val)
+    result = unpack(f">{len(val) // 8}d", val)
     return result if len(result) != 1 else result[0]
+
 
 def _parse_int_bytes(val: bytes) -> int | Sequence[int]:
     r"""Parse (big-endian) bytes to int.
@@ -531,8 +533,9 @@ def _parse_int_bytes(val: bytes) -> int | Sequence[int]:
     >>> _parse_int_bytes(one*3)
     (1, 1, 1)
     """
-    result = unpack(f">{len(val)//4}i", val)
+    result = unpack(f">{len(val) // 4}i", val)
     return result if len(result) != 1 else result[0]
+
 
 def _parse_bool_bytes(val: bytes) -> bool | Sequence[bool]:
     r"""Parse (big-endian) bytes to bool.
@@ -558,8 +561,9 @@ def _parse_bool_bytes(val: bytes) -> bool | Sequence[bool]:
     >>> _parse_bool_bytes(one*3)
     (True, True, True)
     """
-    result = tuple(map(bool, unpack(f">{len(val)//4}i", val)))
+    result = tuple(map(bool, unpack(f">{len(val) // 4}i", val)))
     return result if len(result) != 1 else result[0]
+
 
 def _parse_complex_bytes(val: bytes) -> complex | Sequence[complex]:
     r"""Parse (big-endian) bytes to complex.
@@ -585,9 +589,10 @@ def _parse_complex_bytes(val: bytes) -> complex | Sequence[complex]:
     >>> _parse_complex_bytes((one+one)*3)
     ((1+1j), (1+1j), (1+1j))
     """
-    tmp = unpack(f">{len(val)//8}d", val)
+    tmp = unpack(f">{len(val) // 8}d", val)
     result = tuple(map(complex, tmp[::2], tmp[1::2]))
     return result if len(result) != 1 else result[0]
+
 
 _TYPE_PARSERS: dict[type, Callable] = {float: _parse_float_or_rational,
                                        bool: _parse_logical}
@@ -717,6 +722,7 @@ def _strip_inline_comments(
 
         yield line
 
+
 def _strip_initial_comments(
         data: TextIO | FileWrapper | Block,
         *,
@@ -759,6 +765,7 @@ def _strip_initial_comments(
     data = map(str.rstrip, data)
     data = filter(None, data)
     yield from data
+
 
 def strip_comments(
         data: TextIO | FileWrapper | Block,
@@ -853,6 +860,7 @@ def get_only(seq: Sequence[T]) -> T:
 
     return val
 
+
 def file_or_path(*, mode: Literal["r", "rb"], **open_kwargs: Any) -> Callable:  # paramspec 3.10+
     """Decorate to allow a parser to accept either a path or open file.
 
@@ -860,6 +868,11 @@ def file_or_path(*, mode: Literal["r", "rb"], **open_kwargs: Any) -> Callable:  
     ----------
     mode : Literal["r", "rb"]
         Open mode if passed a :class:`~pathlib.Path` or :class:`str`.
+
+    Returns
+    -------
+    Callable
+        Wrapped function able to handle open files or paths invisibly.
     """
     def inner(func: Callable) -> Callable:
         @wraps(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ extend-exclude = [
 
 [tool.ruff.lint]
 # Allow unused variables when underscore-prefixed.
+preview = true
 select = [
     "PL",  # Pylint
     "E",   # Pycodestyle
@@ -99,8 +100,9 @@ select = [
     "UP",  # Pyupgrade
 ]
 ignore = [
-    "PLR0913",  # Too many arguments
     "PLR0912",  # Too many branches
+    "PLR0913",  # Too many arguments
+    "PLR0914",  # Too many locals
     "PLR0915",  # Too many statements
     "PLW2901",  # For loop variable overwritten
     "PLR2004",  # Magic constant value


### PR DESCRIPTION
Some checks including `DOC` were not enabled without `preview = true`. 

Add `preview = true` and fix associated errors.
Fix issue with `Self` in `FileWrapper` having two definitions.