### PR TITLE
Fix issue with reading external files

### DIFF
--- a/castep_outputs/parsers/castep_file_parser.py
+++ b/castep_outputs/parsers/castep_file_parser.py
@@ -220,8 +220,13 @@ def parse_castep_file(castep_file_in: TextIO,
             curr_run["time_started"] = normalise_string(line.split(":", 1)[1])
 
         # Finalisation
-        elif block := Block.from_re(line, castep_file, "Initialisation time", REs.EMPTY,
+        elif block := Block.from_re(line, castep_file, "Initialisation time", f"{REs.EMPTY}|<",
                                     eof_possible=True):
+
+            # External files present
+            if "<" in block[-1]:
+                block.remove_bounds(0, 1)
+                castep_file.rewind()
 
             if Filters.SYS_INFO not in to_parse:
                 continue

--- a/castep_outputs/parsers/err_file_parser.py
+++ b/castep_outputs/parsers/err_file_parser.py
@@ -32,7 +32,7 @@ def parse_err_file(err_file: TextIO) -> ErrFileInfo:
     """
     accum: ErrFileInfo = {"message": "", "stack": []}
 
-    while "Current trace stack" not in (line := err_file.readline()):
+    while "Current trace stack" not in (line := next(err_file)):
         accum["message"] += line
     accum["message"] = accum["message"].strip()
 

--- a/castep_outputs/parsers/md_geom_file_parser.py
+++ b/castep_outputs/parsers/md_geom_file_parser.py
@@ -140,7 +140,7 @@ def parse_md_geom_file(md_geom_file: TextIO) -> list[MDGeomTimestepInfo]:
         else:
             logger("Invalid md/geom file: no 'END header'.", level="error")
             raise ValueError("Invalid md/geom file: no 'END header'.")
-        md_geom_file.readline()
+        next(md_geom_file)
     else:
         logger("Non-standard md/geom file: missing header.", level="warning")
 

--- a/castep_outputs/parsers/xrd_sf_file_parser.py
+++ b/castep_outputs/parsers/xrd_sf_file_parser.py
@@ -50,7 +50,7 @@ def parse_xrd_sf_file(xrd_sf_file: TextIO) -> XRDSFFileInfo:
         Parsed info.
     """
     # Get headers from first line
-    headers = xrd_sf_file.readline().split()[3:]
+    headers = next(xrd_sf_file).split()[3:]
     # Turn Re(x) into x_re
     headers = [f"{head[3:-1]}_{head[0:2]}".lower() for head in headers]
     headers_wo = {head[:-3] for head in headers}

--- a/castep_outputs/utilities/utility.py
+++ b/castep_outputs/utilities/utility.py
@@ -226,7 +226,7 @@ def normalise(obj, mapping):
     Returns
     -------
     Any
-        Normmalised data.
+        Normalised data.
     """
     if isinstance(obj, (tuple, list)):
         obj = tuple(normalise(v, mapping) for v in obj)
@@ -326,7 +326,8 @@ def flatten_dict(
     """
     items: list[tuple[Any, Any]] = []
     for key, value in dictionary.items():
-        new_key = str(parent_key) + separator + key if parent_key else key
+        # Temporary hack because `None` used as key in species_pot
+        new_key = str(parent_key) + separator + str(key) if parent_key else key
         if isinstance(value, collections.abc.MutableMapping):
             items.extend(flatten_dict(value, new_key, separator).items())
         elif isinstance(value, (list, tuple)):

--- a/castep_outputs/utilities/utility.py
+++ b/castep_outputs/utilities/utility.py
@@ -327,7 +327,7 @@ def flatten_dict(
     items: list[tuple[Any, Any]] = []
     for key, value in dictionary.items():
         # Temporary hack because `None` used as key in species_pot
-        new_key = str(parent_key) + separator + str(key) if parent_key else key
+        new_key = f"{parent_key}{separator}{key}" if parent_key else key
         if isinstance(value, collections.abc.MutableMapping):
             items.extend(flatten_dict(value, new_key, separator).items())
         elif isinstance(value, (list, tuple)):

--- a/test/test_castep_parser.py
+++ b/test/test_castep_parser.py
@@ -4231,6 +4231,46 @@ Total polarisation          0.000000    0.000000    0.224787
         )
 
 
+def test_external_files():
+    test_text = io.StringIO("""
+
+Initialisation time =     24.02 s
+Calculation time    =     50.26 s
+Finalisation time   =    260.34 s
+Total time          =    334.62 s
+Peak Memory Use     = 1703440 kB
+<BEGIN xrd_sf>
+   h   k   l   Re(F_PAW)   Im(F_PAW)   Re(F_IAM)   Im(F_IAM)    Re(F_PP)    Im(F_PP)  Re(F_core)  Im(F_core)  Re(F_soft)  Im(F_soft)   Re(F_aug)   Im(F_aug)
+   0   0   0  112.000000    0.000000  112.000000    0.000000  112.000000    0.000000   80.000000    0.000000   32.345904    0.000000   -0.345904    0.000000
+   1   1   1   42.458193  -42.458196   41.764535  -41.764535   42.447674  -42.447678   37.403844  -37.403844    5.136414   -5.136414   -0.082065    0.082062
+<END xrd_sf>
+""")
+
+    test_dict = parse_castep_file(test_text, filters=Filters.SYS_INFO | Filters.TESTING)[0]
+
+    pprint.pprint(test_dict)
+    assert test_dict == {
+        'calculation_time': 50.26,
+        'external_files': {'xrd_sf': {'f_aug': [(-0.345904+0j),
+                                                (-0.082065+0.082062j)],
+                                      'f_core': [(80+0j),
+                                                 (37.403844-37.403844j)],
+                                      'f_iam': [(112+0j),
+                                                (41.764535-41.764535j)],
+                                      'f_paw': [(112+0j),
+                                                (42.458193-42.458196j)],
+                                      'f_pp': [(112+0j),
+                                               (42.447674-42.447678j)],
+                                      'f_soft': [(32.345904+0j),
+                                                 (5.136414-5.136414j)],
+                                      'qvec': [(0, 0, 0),
+                                               (1, 1, 1)]}},
+        'finalisation_time': 260.34,
+        'initialisation_time': 24.02,
+        'peak_memory_use': 1703440.0,
+        'total_time': 334.62}
+
+
 castep_path = os.environ.get("CASTEP_ROOT")
 castep_tests = (
     Path(castep_path).glob("Test/**/benchmark.out.*") if castep_path is not None else (Path.cwd(),)


### PR DESCRIPTION
- Old end_re didn't allow `<begin XXX>` blocks.
  - If present back up and process 
- `readline` is not present on `FileWrapper`s, `next` is universal.