### PR TITLE
Add flag to force output to always be in dict{file: data} format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,12 +161,12 @@ Full usage
 
    usage: castep_outputs [-h] [-V] [-L {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                          [-o OUTPUT] [-f {json,ruamel,pyyaml,pprint,print}]
-                         [-t] [-A] [--inc-castep] [--inc-cell] [--inc-param]
-                         [--inc-geom] [--inc-md] [--inc-bands] [--inc-hug]
-                         [--inc-phonon_dos] [--inc-efield] [--inc-xrd_sf]
-                         [--inc-elf_fmt] [--inc-chdiff_fmt] [--inc-pot_fmt]
-                         [--inc-den_fmt] [--inc-elastic] [--inc-ts]
-                         [--inc-magres] [--inc-tddft] [--inc-err]
+                         [-t] [-m] [-A] [--inc-castep] [--inc-cell]
+                         [--inc-param] [--inc-geom] [--inc-md] [--inc-bands]
+                         [--inc-hug] [--inc-phonon_dos] [--inc-efield]
+                         [--inc-xrd_sf] [--inc-elf_fmt] [--inc-chdiff_fmt]
+                         [--inc-pot_fmt] [--inc-den_fmt] [--inc-elastic]
+                         [--inc-ts] [--inc-magres] [--inc-tddft] [--inc-err]
                          [--inc-phonon] [--inc-epme] [--inc-cst_esp]
                          [--inc-epme_bin] [--castep [CASTEP ...]]
                          [--cell [CELL ...]] [--param [PARAM ...]]
@@ -203,6 +203,8 @@ Full usage
      -f, --out-format {json,ruamel,pyyaml,pprint,print}
                            Output format
      -t, --testing         Set testing mode to produce flat outputs
+     -m, --always-filename
+                           Always output dict{filename: data}
      -A, --inc-all         Extract all available information
      --inc-castep          Extract .castep information
      --inc-cell            Extract .cell information

--- a/castep_outputs/cli/args.py
+++ b/castep_outputs/cli/args.py
@@ -44,6 +44,8 @@ def get_parser() -> argparse.ArgumentParser:
 
     arg_parser.add_argument("-t", "--testing", action="store_true",
                             help="Set testing mode to produce flat outputs")
+    arg_parser.add_argument("-m", "--always-filename", action="store_true",
+                            help="Always output dict{filename: data}")
 
     arg_parser.add_argument("-A", "--inc-all", action="store_true",
                             help="Extract all available information")

--- a/castep_outputs/cli/castep_outputs_main.py
+++ b/castep_outputs/cli/castep_outputs_main.py
@@ -101,6 +101,7 @@ def parse_all(
         *,
         loglevel: int = logging.WARNING,
         testing: bool = False,
+        always_dict: bool = False,
         **files: Sequence[Path],
 ) -> None:
     """
@@ -127,7 +128,7 @@ def parse_all(
         for path in paths:
             data[path] = parse_single(path, parser, out_format, loglevel=loglevel, testing=testing)
 
-    if len(data) == 1:
+    if not always_dict and len(data) == 1:
         data = data.popitem()[1]
 
     if output is None:
@@ -154,6 +155,7 @@ def run(args: argparse.Namespace) -> None:
               loglevel=getattr(logging, args.log.upper()),
               testing=args.testing,
               out_format=args.out_format,
+              always_dict=args.always_filename,
               **dict_args)
 
 


### PR DESCRIPTION
Given changing the default would be API breaking, add flag to enforce output as dictionary even for single-file processing.  

Fixes #279 